### PR TITLE
Update to Minecraft 1.15.1, fix tooltip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.5-SNAPSHOT'
+	id 'fabric-loom' version '0.2.6-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -15,9 +15,9 @@ minecraft {
 
 dependencies {
 	//to change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:1.14.4"
-	mappings "net.fabricmc:yarn:1.14.4+build.12"
-	modCompile "net.fabricmc.fabric-api:fabric-api:0.3.2+build.226-1.14"
+	minecraft "com.mojang:minecraft:1.15.1"
+	mappings "net.fabricmc:yarn:1.15.1+build.6:v2"
+	modCompile "net.fabricmc.fabric-api:fabric-api:0.4.25+build.282-1.15"
 	
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.14.4
-	yarn_mappings=1.14.4+build.12
-	loader_version=0.6.1+build.165
+	minecraft_version=1.15.1
+	yarn_mappings=1.15.1+build.6
+	loader_version=0.7.2+build.175
 
 # Mod Properties
-	mod_version = 1.1.5
+	mod_version = 1.1.6
 	maven_group = net.fabricmc
 	archives_base_name = MpcsBackpacks
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
-	fabric_version=0.3.2+build.226-1.14
+	fabric_version=0.4.25+build.282-1.15

--- a/src/main/java/io/github/mpcs/BackpackItem.java
+++ b/src/main/java/io/github/mpcs/BackpackItem.java
@@ -1,6 +1,5 @@
 package io.github.mpcs;
 
-import com.sun.istack.internal.Nullable;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
@@ -11,14 +10,11 @@ import net.minecraft.item.DyeableItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.*;
-import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
-import java.util.Iterator;
 import java.util.List;
 
 public class BackpackItem extends Item implements DyeableItem {
@@ -55,44 +51,36 @@ public class BackpackItem extends Item implements DyeableItem {
         }
         Inventories.fromTag(nbt, defaultedList);
         backpack.setTag(nbt);
-
     }
 
-
+    @Override
     @Environment(EnvType.CLIENT)
-    public void buildTooltip(ItemStack itemStack_1, @Nullable BlockView blockView_1, List<Text> list_1, TooltipContext tooltipContext_1) {
-        this.buildTooltip(itemStack_1, blockView_1, list_1, tooltipContext_1);
-        CompoundTag compoundTag_1 = itemStack_1.getSubTag("BlockEntityTag");
-        if (compoundTag_1 != null) {
-            if (compoundTag_1.containsKey("LootTable", 8)) {
-                list_1.add(new LiteralText("???????"));
-            }
+    public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
+        super.appendTooltip(stack, world, tooltip, context);
+        CompoundTag tag = stack.getTag();
+        if (tag != null) {
+            if (tag.contains("Items", 9)) {
+                DefaultedList<ItemStack> stacks = DefaultedList.ofSize(27, ItemStack.EMPTY);
+                Inventories.fromTag(tag, stacks);
+                int listedStacks = 0;
+                int totalStacks = 0;
 
-            if (compoundTag_1.containsKey("Items", 9)) {
-                DefaultedList<ItemStack> defaultedList_1 = DefaultedList.ofSize(27, ItemStack.EMPTY);
-                Inventories.fromTag(compoundTag_1, defaultedList_1);
-                int int_1 = 0;
-                int int_2 = 0;
-                Iterator var9 = defaultedList_1.iterator();
-
-                while(var9.hasNext()) {
-                    ItemStack itemStack_2 = (ItemStack)var9.next();
-                    if (!itemStack_2.isEmpty()) {
-                        ++int_2;
-                        if (int_1 <= 4) {
-                            ++int_1;
-                            Text text_1 = itemStack_2.getName().deepCopy();
-                            text_1.append(" x").append(String.valueOf(itemStack_2.getCount()));
-                            list_1.add(text_1);
+                for (ItemStack heldStack : stacks) {
+                    if (!heldStack.isEmpty()) {
+                        ++totalStacks;
+                        if (listedStacks <= 4) {
+                            ++listedStacks;
+                            Text stackName = heldStack.getName().deepCopy();
+                            stackName.append(" x").append(String.valueOf(heldStack.getCount()));
+                            tooltip.add(stackName);
                         }
                     }
                 }
 
-                if (int_2 - int_1 > 0) {
-                    list_1.add((new TranslatableText("container.shulkerBox.more", new Object[]{int_2 - int_1})).formatted(Formatting.ITALIC));
+                if (totalStacks - listedStacks > 0) {
+                    tooltip.add((new TranslatableText("container.shulkerBox.more", new Object[]{totalStacks - listedStacks})).formatted(Formatting.ITALIC));
                 }
             }
         }
-
     }
 }

--- a/src/main/java/io/github/mpcs/container/BackpackScreen.java
+++ b/src/main/java/io/github/mpcs/container/BackpackScreen.java
@@ -27,14 +27,14 @@ public class BackpackScreen extends AbstractContainerScreen<BackpackContainer> {
     @Override
     protected void init() {
         super.init();
-        this.left = (this.width - this.containerWidth) / 2;
+        this.x = (this.width - this.containerWidth) / 2;
     }
 
     @Override
     protected void drawBackground(float var1, int var2, int var3) {
         GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         this.minecraft.getTextureManager().bindTexture(TEXTURE);
-        int guiX = this.left;
+        int guiX = this.x;
         int guiY = (this.height - this.containerHeight) / 2;
         this.blit(guiX, guiY, 0, 0, this.containerWidth, this.containerHeight);
 


### PR DESCRIPTION
- no longer crashes on Minecraft 1.15.1
- tooltip properly displays